### PR TITLE
[JENKINS-47884] - Add "View" to the plugin's name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
 
 
-   <name>Pipeline Aggregator</name>
+   <name>Pipeline Aggregator View</name>
    <description>Agregates the pipelines on a dashboard like view</description>
    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Aggregator+View</url>
 


### PR DESCRIPTION
For a long time there was a Pipeline Aggregator plugin, which was renamed to just Pipeline plugin. This new plugin uses name of the former plugin, and it may confuse users. I propose to add "View" to the name

https://issues.jenkins-ci.org/browse/JENKINS-47884

@reviewbybees