### PR TITLE
Allow column selection in the pipeline aggregation screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ The View offers a simple functionality of showing latest pipeline build togheter
 From the view you can navigate back to the build number that was generated.
 
 
-![Fullscreen](./screenshots/AggregatedPipeline.png?raw=true =625x)
+![Fullscreen](./screenshots/AggregatedPipeline.png?raw=true&width=625x)

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
    <groupId>com.paul8620.jenkins.plugins</groupId>
    <artifactId>pipeline-aggregator-view</artifactId>
-   <version>1.9-SNAPSHOT</version>
+   <version>1.9.1-SNAPSHOT</version>
    <packaging>hpi</packaging>
 
    <properties>

--- a/src/main/java/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator.java
+++ b/src/main/java/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator.java
@@ -47,6 +47,11 @@ public class PipelineAggregator extends View {
 
    private String filterRegex;
 
+   private boolean showCommitInfo;
+   private boolean showBuildNumber;
+   private boolean showBuildTime;
+   private boolean showBuildDuration;
+
    @DataBoundConstructor
    public PipelineAggregator(String name, String viewName) {
       super(name);
@@ -56,6 +61,11 @@ public class PipelineAggregator extends View {
       this.useCondensedTables = false;
 	  this.onlyLastBuild = false;
       this.filterRegex = null;
+
+      this.showCommitInfo = true;
+      this.showBuildNumber = true;
+      this.showBuildTime = true;
+      this.showBuildDuration = true;
    }
 
    protected Object readResolve() {
@@ -82,6 +92,38 @@ public class PipelineAggregator extends View {
    public boolean isUseCondensedTables() {
       return useCondensedTables;
    }
+
+    public boolean isShowCommitInfo() {
+        return showCommitInfo;
+    }
+
+    public void setShowCommitInfo(boolean showCommitInfo) {
+        this.showCommitInfo = showCommitInfo;
+    }
+
+    public boolean isShowBuildNumber() {
+        return showBuildNumber;
+    }
+
+    public void setShowBuildNumber(boolean showBuildNumber) {
+        this.showBuildNumber = showBuildNumber;
+    }
+
+    public boolean isShowBuildTime() {
+        return showBuildTime;
+    }
+
+    public void setShowBuildTime(boolean showBuildTime) {
+        this.showBuildTime = showBuildTime;
+    }
+
+    public boolean isShowBuildDuration() {
+        return showBuildDuration;
+    }
+
+    public void setShowBuildDuration(boolean showBuildDuration) {
+        this.showBuildDuration = showBuildDuration;
+    }
 
 	public boolean isUseScrollingCommits() {
 		return useScrollingCommits;
@@ -114,7 +156,13 @@ public class PipelineAggregator extends View {
       this.buildHistorySize = json.getInt("buildHistorySize");
       this.useCondensedTables = json.getBoolean("useCondensedTables");
       this.useScrollingCommits = json.getBoolean("useScrollingCommits");
-		this.onlyLastBuild = json.getBoolean("onlyLastBuild");
+      this.onlyLastBuild = json.getBoolean("onlyLastBuild");
+
+      this.showCommitInfo = json.getBoolean("showCommitInfo");
+      this.showBuildNumber = json.getBoolean("showBuildNumber");
+      this.showBuildTime = json.getBoolean("showBuildTime");
+      this.showBuildDuration = json.getBoolean("showBuildDuration");
+
       if (json.get("useRegexFilter") != null) {
          String regexToTest = req.getParameter("filterRegex");
          try {

--- a/src/main/java/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator.java
+++ b/src/main/java/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator.java
@@ -39,6 +39,8 @@ public class PipelineAggregator extends View {
 
    private int buildHistorySize;
 
+   private int refreshInterval;
+
    private boolean useCondensedTables;
    
    private boolean onlyLastBuild;
@@ -58,6 +60,7 @@ public class PipelineAggregator extends View {
       this.viewName = viewName;
       this.fontSize = 16;
       this.buildHistorySize = 16;
+      this.refreshInterval = 15;
       this.useCondensedTables = false;
 	  this.onlyLastBuild = false;
       this.filterRegex = null;
@@ -73,6 +76,8 @@ public class PipelineAggregator extends View {
          fontSize = 16;
       if (buildHistorySize == 0)
          buildHistorySize = 16;
+      if (refreshInterval == 0)
+         refreshInterval = 15;
       return this;
    }
 
@@ -149,11 +154,20 @@ public class PipelineAggregator extends View {
       return filterRegex;
    }
 
+   public int getRefreshInterval() {
+      return refreshInterval;
+   }
+
+   public void setRefreshInterval(int refreshInterval) {
+      this.refreshInterval = refreshInterval;
+   }
+
    @Override
    protected void submit(StaplerRequest req) throws ServletException, IOException {
       JSONObject json = req.getSubmittedForm();
       this.fontSize = json.getInt("fontSize");
       this.buildHistorySize = json.getInt("buildHistorySize");
+      this.refreshInterval = json.getInt("refreshInterval");
       this.useCondensedTables = json.getBoolean("useCondensedTables");
       this.useScrollingCommits = json.getBoolean("useScrollingCommits");
       this.onlyLastBuild = json.getBoolean("onlyLastBuild");

--- a/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/configure-entries.jelly
+++ b/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/configure-entries.jelly
@@ -17,9 +17,6 @@
         <f:entry title="${%Use condensed tables}">
             <f:checkbox name="useCondensedTables" field="useCondensedTables" />
         </f:entry>
-        <f:entry title="${%Hide build information}">
-            <f:checkbox name="hideBuildInfo" field="hideBuildInfo" />
-        </f:entry>
         <f:entry title="${%Use auto-rolling commits}">
             <f:checkbox name="useScrollingCommits" field="useScrollingCommits" />
         </f:entry>

--- a/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/configure-entries.jelly
+++ b/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/configure-entries.jelly
@@ -14,6 +14,9 @@
         <f:entry title="${%Records in build history}">
             <f:number name="buildHistorySize" value="${it.buildHistorySize}" />
         </f:entry>
+        <f:entry title="${%Refresh interval}">
+            <f:number name="refreshInterval" value="${it.refreshInterval}" />
+        </f:entry>
         <f:entry title="${%Use condensed tables}">
             <f:checkbox name="useCondensedTables" field="useCondensedTables" />
         </f:entry>

--- a/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/configure-entries.jelly
+++ b/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/configure-entries.jelly
@@ -17,11 +17,28 @@
         <f:entry title="${%Use condensed tables}">
             <f:checkbox name="useCondensedTables" field="useCondensedTables" />
         </f:entry>
+        <f:entry title="${%Hide build information}">
+            <f:checkbox name="hideBuildInfo" field="hideBuildInfo" />
+        </f:entry>
         <f:entry title="${%Use auto-rolling commits}">
             <f:checkbox name="useScrollingCommits" field="useScrollingCommits" />
         </f:entry>
         <f:entry title="${%Only display last build}">
             <f:checkbox name="onlyLastBuild" field="onlyLastBuild" />
+        </f:entry>
+    </f:section>
+    <f:section title="${%Field selection}">
+        <f:entry title="${%Show commit info}">
+            <f:checkbox name="showCommitInfo" field="showCommitInfo" />
+        </f:entry>
+        <f:entry title="${%Show build number}">
+            <f:checkbox name="showBuildNumber" field="showBuildNumber" />
+        </f:entry>
+        <f:entry title="${%Show build time}">
+            <f:checkbox name="showBuildTime" field="showBuildTime" />
+        </f:entry>
+        <f:entry title="${%Show build duration}">
+            <f:checkbox name="showBuildDuration" field="showBuildDuration" />
         </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/index.jelly
+++ b/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/index.jelly
@@ -22,7 +22,7 @@
         <body class="height100perc">
             <script type="text/javascript">
                 var jenkinsUrl = '${rootURL}';
-                var refreshInterval = 15*1000;
+                var refreshInterval = ${it.refreshInterval}*1000;
                 var nodeStatuses = [];
                 var buildHistorySize = ${it.buildHistorySize};
                 var useScrollingCommits= ${it.useScrollingCommits};

--- a/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/index.jelly
+++ b/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/index.jelly
@@ -20,6 +20,24 @@
             </style>
         </head>
         <body class="height100perc">
+            <script type="text/javascript">
+                var jenkinsUrl = '${rootURL}';
+                var refreshInterval = 15*1000;
+                var nodeStatuses = [];
+                var buildHistorySize = ${it.buildHistorySize};
+                var useScrollingCommits= ${it.useScrollingCommits};
+                var onlyLastBuild= ${it.onlyLastBuild};
+                var showCommitInfo = ${it.showCommitInfo};
+                var showBuildNumber = ${it.showBuildNumber};
+                var showBuildTime = ${it.showBuildTime};
+                var showBuildDuration = ${it.showBuildDuration};
+                var rollingCommits = false;
+                function reload_info (interval) {
+                    reload_jenkins_build_history('#jenkinsBuildHistory', jenkinsUrl + '/${it.url}', buildHistorySize, useScrollingCommits, onlyLastBuild, showCommitInfo, showBuildNumber, showBuildTime, showBuildDuration);
+                    setTimeout(function(){ reload_info(interval); }, interval);
+                }
+            </script>
+
             <a href="${rootURL}/${it.url}configure" alt="Configure view">
                 <div class="abs-top-right">
                     <span class="glyphicon glyphicon-cog"></span>
@@ -33,8 +51,22 @@
                         <!-- VIEW_URL/api/json -->
                         <table id="jenkinsBuildHistory" class="table table-striped table-bordered ${it.tableStyle}">
                             <thead>
-                                <tr><th class="text-left">${%Job}</th><th>Stages</th><th>${%Commits}</th><th>${%Build}</th><th>${%Finished}</th><th>${%Duration
-                                }</th></tr>
+                                <tr><th class="text-left">${%Job}</th><th class="text-left">Stages</th>
+                                <script type="text/javascript">
+                                    if(showCommitInfo) {
+                                        document.write("<th>${%Commits}</th>");
+                                    }
+                                    if(showCommitInfo) {
+                                        document.write("<th>${%Build}</th>");
+                                    }
+                                    if(showBuildTime) {
+                                        document.write("<th>${%Finished}</th>");
+                                    }
+                                    if(showBuildDuration) {
+                                        document.write("<th>${%Duration}</th>");
+                                    }
+                                </script>
+                                </tr>
                             </thead>
                             <tbody></tbody>
                         </table>
@@ -45,18 +77,7 @@
             <script src="${rootURL}/plugin/pipeline-aggregator-view/lib/bootstrap.min.js"></script>
             <script src="${rootURL}/plugin/pipeline-aggregator-view/js/pipeline-aggregator.js"></script>
             <script type="text/javascript">
-                var jenkinsUrl = '${rootURL}';
-                var refreshInterval = 15*1000;
-                var nodeStatuses = [];
-                var buildHistorySize = ${it.buildHistorySize};
-                var useScrollingCommits= ${it.useScrollingCommits};
-                var onlyLastBuild= ${it.onlyLastBuild};
-                var rollingCommits = false;
-                function reload_info (interval) {
-                    reload_jenkins_build_history('#jenkinsBuildHistory', jenkinsUrl + '/${it.url}', buildHistorySize, useScrollingCommits, onlyLastBuild);
-                    setTimeout(function(){ reload_info(interval); }, interval);
-                }
-
+                var $$ = jQuery;
                 $$(document).ready(function(){
                     $$.ajaxSetup({ cache: false });
                     reload_info(refreshInterval);

--- a/src/main/webapp/css/pipeline-aggregator.css
+++ b/src/main/webapp/css/pipeline-aggregator.css
@@ -31,6 +31,8 @@ a {
 .btn {
   font-size: 14px;
   background-color: transparent;
+  border-radius: 3px !important;
+  margin: 1px 1px 1px 0 !important;
 }
 
 .btn-success {

--- a/src/main/webapp/js/pipeline-aggregator.js
+++ b/src/main/webapp/js/pipeline-aggregator.js
@@ -30,7 +30,7 @@ function format_interval(iv) {
    return ivStr;
 }
 
-function reload_jenkins_build_history(tableSelector, viewUrl, buildHistorySize, useScrollingCommits, onlyLastBuild) {
+function reload_jenkins_build_history(tableSelector, viewUrl, buildHistorySize, useScrollingCommits, onlyLastBuild, showCommitInfo, showBuildNumber, showBuildTime, showBuildDuration) {
    $.getJSON(viewUrl + 'api/json', function (data) {
       // Remove all existing rows
       $(tableSelector + ' tbody').find('tr').remove();
@@ -98,11 +98,23 @@ function reload_jenkins_build_history(tableSelector, viewUrl, buildHistorySize, 
             }
             stages += '</div>'
 
-            newRow = '<tr><td class="job-wrap text-left">' + bame + '</td><td class="text-left">' + stages + '</td><td>' + authors + '</td><td>' + val.number + '</td><td>' + format_date(dt) + '</td><td>' + format_interval(val.duration) + '</td></trcla>';
+            newRow = '<tr><td class="job-wrap text-left">' + bame + '</td><td class="text-left">' + stages + '</td>';
+            if(showCommitInfo) {
+                newRow += '<td>' + authors + '</td>';
+            }
+            if(showBuildNumber) {
+                newRow += '<td>' + val.number + '</td>';
+            }
+            if(showBuildTime) {
+                newRow += '<td>' + format_date(dt) + '</td>';
+            }
+            if(showBuildDuration) {
+                newRow += '<td>' + format_interval(val.duration) + '</td>';
+            }
+            newRow += '</tr>';
             $(tableSelector + ' tbody').append(newRow);
          });
 
       });
    });
 }
-


### PR DESCRIPTION
Config screen have been extended with checkbox to show/hide the following columns:

* commit info
* build number
* build finish time
* build duration

Each of these columns can be shown or hidden based on the selection.