### PR TITLE
[Hacktoberfest] Migrate README from wiki to plugin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Aggregated Pipeline View
 
-The Aggregated Pipeline View offers a simple functionality of showing the latest pipeline build together with its stages. It allows the users to view the history of their pipelines with stage information (failed/In Progress/Passed) and the changes monitored.
+The Aggregated Pipeline View offers a simple functionality of showing the latest pipeline build together with its stages. 
+It allows the users to view the history of their pipelines with stage information (failed/In Progress/Passed) and the changes monitored.
 
 ![Aggregated Pipeline View](screenshots/AggregatedPipeline.png)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,27 @@
 # Aggregated Pipeline View
 
-The View offers a simple functionality of showing latest pipeline build togheter with their stages. 
-From the view you can navigate back to the build number that was generated.
+The Aggregated Pipeline View offers a simple functionality of showing the latest pipeline build together with its stages. It allows the users to view the history of their pipelines with stage information (failed/In Progress/Passed) and the changes monitored.
 
+![Aggregated Pipeline View](screenshots/AggregatedPipeline.png)
 
-![Fullscreen](./screenshots/AggregatedPipeline.png?raw=true =625x)
+Releases:
+
+-   1.8 Added the option for showing only the last build of a pipeline
+    matching the patterns
+-   1.7 bugfixes
+-   1.6 filter applied on full display name making it easy not to filter
+    multibranch projects and branchest within its regex:
+     multibranch-project-name.+(branch1\|branch2\|branch3) \#\[0-9\]+  
+     
+-   1.5 fixed a bug that didn't allow multibranch projects to be
+    filtered correctly
+-   1.4: fixed the auto-refresh
+-   1.3: Added option to remove the auto-scrolling of the commits 
+    -   fixed <https://issues.jenkins-ci.org/browse/JENKINS-40008>
+    -   fixed <https://issues.jenkins-ci.org/browse/JENKINS-39993>
+-   1.2: fixed the href issue and added auto-scrolling to the list of
+    commit
+-   1.1: fixed an issue that didn't allow the folder or renamed builds
+    to be displayed
+-   1.0: initial release a dashboard like view that selects only
+    pipelines and presents the stages and the commits on each build.

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
    <name>Pipeline Aggregator View</name>
    <description>Agregates the pipelines on a dashboard like view</description>
-   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Aggregator+View</url>
+   <url>github.com/jenkinsci/pipeline-aggregator-view-plugin</url>
 
    <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
 


### PR DESCRIPTION
This PR migrates the Pipeline Aggregator View plugin Readme information from the plugins-wiki-docs repo to the pipeline-aggregator-view-plugin repo. The README.md file and the pom.xml files were updated accordingly.

Since there was an existing README in the pipeline-aggregator-view-plugin repo, I merged the existing information with the information from the wiki.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
