### PR TITLE
Fix failed to parse index.jelly

### DIFF
--- a/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/index.jelly
+++ b/src/main/resources/com/ooyala/jenkins/plugins/pipelineaggregatorview/PipelineAggregator/index.jelly
@@ -1,4 +1,4 @@
-<j: xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
     <st:contentType value="text/html;charset=UTF-8" />
     <j:new var="h" className="hudson.Functions"/>
     ${h.initPageVariables(context)}
@@ -85,4 +85,4 @@
             </script>
         </body>
     </html>
-</j:>
+</j:jelly>


### PR DESCRIPTION
Opening any Pipeline Aggregator View on recent versions of Jenkins results in `Failed to parse index.jelly for MetaClass[class com.ooyala.jenkins.plugins.pipelineaggregatorview.PipelineAggregator`