### PR TITLE
Fix documentation URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,14 +66,14 @@
 
    <name>Pipeline Aggregator View</name>
    <description>Agregates the pipelines on a dashboard like view</description>
-   <url>github.com/jenkinsci/pipeline-aggregator-view-plugin</url>
+   <url>https://github.com/jenkinsci/pipeline-aggregator-view-plugin</url>
 
    <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
 
    <licenses>
       <license>
          <name>MIT License</name>
-         <url>http://opensource.org/licenses/MIT</url>
+         <url>https://opensource.org/licenses/MIT</url>
       </license>
    </licenses>
 


### PR DESCRIPTION
The website cannot find plugin documentation: https://plugins.jenkins.io/pipeline-aggregator-view/

Using the full URL including protocol should fix it.